### PR TITLE
upgrade to sdk 11.5.8.1. Major breaking changes to binj interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,36 +2,64 @@
 
 Clojure library to access the Bing Ads reporting API.
 
+[![Clojars Project](https://img.shields.io/clojars/v/uswitch/binj.svg)](https://clojars.org/uswitch/binj)
+
+## Note Breaking Changes 0.4.0
+
+With version 0.4.0 there are some significant breaking changes to the the way reports are generated.  It now uses the built in
+async polling mechanism provided in the SDK, so it no longer exposes the request-id.  The `submit-and-download` now returns a sequence of maps
+representing the report data.
+
+Authorisation and Report Definitions are the same, however the mechanism to download them is breaking.  Please be aware when upgrading to this version.
+
 ## Example Usage
 
 ```clojure
 (ns example
-  (:require [binj.reporting :as b]))
+  (:require [binj.reporting :as b]
+            [clj-time.core  :as t]))
 
-(def auth (b/authorization-data developer-token username password customer-id account-id))
-(def service (b/reporting-service auth))
+(def auth (b/authorization-data developer-token (b/password-grant username password)))
 
-(def report-request (b/keyword-performance-report-request "name"
-                                                          [account-id]
-                                                          [:time-period :account-name :campaign-name :keyword :impressions :clicks]))
+(def report-request (b/account-performance-report-request
+    "name"
+    [account-id]
+    [:time-period :account-id :account-name :account-number :spend]
+    :aggregation :daily
+    :time-period {:start (t/date-time 2018 3 6) :end (t/date-time 2018 3 6)}))
 
-(let [{:keys [request-id error] :as status} (b/generate-report service report-request)]
-  (when error
-    (println "Error submitting report:" error)
-    (System/exit 1))
+(def results (b/submit-and-download report-request auth))
 
-  (loop [{:keys [report-url status]} (b/poll-report service request-id)]
-    (condp = status
-      :success (let [records (b/record-seq report-url)]
-                 (doseq [r (take 10 records)]
-                   (println r)))
-      :error   (do (println "Error generating report.") (System/exit 1))
-      :pending (do (Thread/sleep 5000) (recur (b/poll-report service request-id))))))
+({"GregorianDate" #object[org.joda.time.DateTime 0x76248127 "2018-03-06T00:00:00.000Z"], "AccountId" "12345", "AccountName" "My Bing Account", "AccountNumber" "X1234567", "Spend" 1234.00})
+
 ```
+
+## Changelog
+
+### Version 0.4.0
+
+- Support for v11 BingAds api
+- breaking changes to report download
+- Polling internalised
+- requires permission to generate a temporary file on the file system
+
+### Version 0.3,0-SNAPSHOT
+
+- Support for v11 BingAds api
+- Broken
+
+### Version 0.2,0-SNAPSHOT
+
+- Support for v10 BingAds api
+
+
+### Version 0.1,2
+
+- Support for v9 BingAds api
 
 ## License
 
-Copyright © 2015, uSwitch.
+Copyright © 2018, uSwitch.
 
 Distributed under the Eclipse Public License either version 1.0 or (at
 your option) any later version.

--- a/project.clj
+++ b/project.clj
@@ -1,10 +1,13 @@
-(defproject binj "0.3.0-SNAPSHOT"
+(defproject uswitch/binj "0.4.0-SNAPSHOT"
   :description "Clojure library to interact with the Bing Ads API"
   :url "https://github.com/uswitch/binj"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.7.0"]
-                 [com.microsoft.bingads/microsoft.bingads "11.5.4"]
-                 [clj-http-lite "0.2.1"]
-                 [clj-time "0.10.0"]
-                 [org.clojure/data.csv "0.1.2"]])
+  :pom-plugins  [[org.apache.maven.plugins/maven-shade-plugin "3.1.0"]]
+  :uberjar-merge-with {"META-INF/cxf/bus-extensions.txt" [slurp str spit] }
+  :dependencies [[org.clojure/clojure                     "1.8.0"]
+                 [com.microsoft.bingads/microsoft.bingads "11.5.8.1"]
+                 [commons-io/commons-io                   "2.5"]
+                 [clj-http-lite                           "0.3.0"]
+                 [clj-time                                "0.14.2"]
+                 [org.clojure/data.csv                    "0.1.4"]])


### PR DESCRIPTION
@pingles Not sure how you feel about this but I have upgrade to support v11.5.8.1 SDK

I've made some major breaking changes to binj, and added some notes in the README to spell this out.  Auth and reports definitions are unchanged, just the mechanism of downloading and polling.

Wanted to simplify the process a lot and make use of the new ReportServiceManager that is in the SDK examples.  I think there were too many public exposed function defn which I either deleted or made private.

I've tested this version in our production instance and it works fine.  Also I'm not sure if the 0.3.0-SNAPSHOT in clojars has been tested? I didn't see how it could work as they have added version numbers to the report namespace.. I didn't try it though.

If you want to merge this then I'd like to bump version to 0.4.0 and release to clojars